### PR TITLE
Mixture distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Tom Spooner <spooner10000@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 
-keywords = ["probability", "statistics"]
+keywords = ["probability", "statistics", "sampling", "distribution"]
 
 repository = "https://github.com/tspooner/rstat"
 documentation = "https://docs.rs/rstat"
@@ -17,6 +17,6 @@ edition = "2018"
 
 [dependencies]
 rand = "0.6"
-spaces = "4.2"
+spaces = "4.3"
 ndarray = "0.12"
 special-fun = "0.1"

--- a/src/continuous/mod.rs
+++ b/src/continuous/mod.rs
@@ -32,3 +32,5 @@ import_all!(rayleigh);
 import_all!(student_t);
 import_all!(triangular);
 import_all!(weibull);
+
+pub type Uniform = crate::Uniform<f64>;

--- a/src/core/probability.rs
+++ b/src/core/probability.rs
@@ -83,6 +83,12 @@ impl Probability {
     }
 }
 
+impl Probability {
+    pub fn non_zero(&self) -> bool {
+        self.0 > 1e-7
+    }
+}
+
 impl fmt::Display for Probability {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/src/core/probability.rs
+++ b/src/core/probability.rs
@@ -44,6 +44,10 @@ impl Probability {
         ProbabilityError::check_bounded(p).map(|p| Probability(p))
     }
 
+    pub(crate) fn new_unchecked(p: f64) -> Probability {
+        Probability(p)
+    }
+
     pub fn zero() -> Probability {
         Probability(0.0)
     }

--- a/src/degenerate.rs
+++ b/src/degenerate.rs
@@ -7,7 +7,7 @@ use spaces::{
 use std::fmt;
 
 #[derive(Debug, Clone, Copy)]
-pub struct Degenerate<T = f64> {
+pub struct Degenerate<T> {
     pub k: T,
 }
 
@@ -174,7 +174,7 @@ impl<T> Entropy for Degenerate<T> {
     }
 }
 
-impl fmt::Display for Degenerate {
+impl<T: fmt::Display> fmt::Display for Degenerate<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "δ(x - {})", self.k)
     }

--- a/src/discrete/categorical.rs
+++ b/src/discrete/categorical.rs
@@ -16,6 +16,10 @@ impl Categorical {
 
         Categorical { ps }
     }
+
+    pub fn n_categories(&self) -> usize {
+        self.ps.len()
+    }
 }
 
 impl Distribution for Categorical {

--- a/src/discrete/categorical.rs
+++ b/src/discrete/categorical.rs
@@ -17,8 +17,18 @@ impl Categorical {
         Categorical { ps }
     }
 
+    pub fn equiprobable(n: usize) -> Categorical {
+        Categorical::new(vec![1.0 / n as f64; n])
+    }
+
     pub fn n_categories(&self) -> usize {
         self.ps.len()
+    }
+}
+
+impl<P: Into<Probability>> From<Vec<P>> for Categorical {
+    fn from(ps: Vec<P>) -> Categorical {
+        Categorical::new(ps)
     }
 }
 

--- a/src/discrete/mod.rs
+++ b/src/discrete/mod.rs
@@ -18,3 +18,5 @@ import_all!(categorical);
 import_all!(geometric);
 import_all!(multinomial);
 import_all!(poisson);
+
+pub type Uniform = crate::Uniform<i64>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,6 @@ pub mod discrete;
 
 import_all!(uniform);
 import_all!(degenerate);
+import_all!(mixture);
 
 pub use self::core::{Distribution, Probability};

--- a/src/mixture.rs
+++ b/src/mixture.rs
@@ -135,20 +135,32 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        Uniform,
+        continuous::{Normal, Uniform},
         core::UnivariateMoments,
     };
     use super::Mixture;
 
     #[test]
     fn test_uniform_pair_mixture() {
-        let uniform = Uniform::<f64>::new(0.0, 2.0);
+        let uniform = Uniform::new(0.0, 2.0);
         let mixture = Mixture::homogeneous(vec![
-            Uniform::<f64>::new(0.0, 1.0),
-            Uniform::<f64>::new(1.0, 2.0),
+            Uniform::new(0.0, 1.0),
+            Uniform::new(1.0, 2.0),
         ]);
 
         assert!((uniform.mean() - mixture.mean()).abs() < 1e-7);
         assert!((uniform.variance() - mixture.variance()).abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_gmm() {
+        let gmm = Mixture::new(
+            vec![0.2, 0.5, 0.3],
+            vec![Normal::new(-2.0, 1.2), Normal::new(0.0, 1.0), Normal::new(3.0, 2.5)],
+        );
+
+        assert!((gmm.mean() - 0.5).abs() < 1e-7);
+        assert!((gmm.variance() - 5.913).abs() < 1e-7);
+        assert!((gmm.standard_deviation() - gmm.variance().sqrt()).abs() < 1e-7);
     }
 }

--- a/src/mixture.rs
+++ b/src/mixture.rs
@@ -1,0 +1,131 @@
+use crate::{
+    core::*,
+    discrete::Categorical,
+};
+use rand::Rng;
+use spaces::{Space, Vector};
+
+#[derive(Debug, Clone)]
+pub struct Mixture<C> {
+    pub dist: Categorical,
+    pub components: Vec<C>,
+}
+
+impl<C> Mixture<C> {
+    pub fn new<T: Into<Categorical>>(prior: T, components: Vec<C>) -> Mixture<C> {
+        let prior: Categorical = prior.into();
+
+        if components.len() != prior.n_categories() {
+            panic!("Number of components must match the number of assigned probabilities.")
+        }
+
+        Mixture {
+            dist: prior.into(),
+            components,
+        }
+    }
+
+    pub fn homogeneous(components: Vec<C>) -> Mixture<C> {
+        let n_components = components.len();
+
+        Mixture::new(Categorical::equiprobable(n_components), components)
+    }
+}
+
+impl<C> Mixture<C> {
+    pub fn n_components(&self) -> usize {
+        self.components.len()
+    }
+}
+
+impl<C: Distribution> Distribution for Mixture<C> {
+    type Support = C::Support;
+
+    fn support(&self) -> Self::Support {
+        unimplemented!()
+    }
+
+    fn cdf(&self, _: <Self::Support as Space>::Value) -> Probability {
+        unimplemented!()
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, _: &mut R) -> <Self::Support as Space>::Value {
+        unimplemented!()
+    }
+}
+
+impl<C: ContinuousDistribution> ContinuousDistribution for Mixture<C>
+where
+    <Self::Support as Space>::Value: Clone
+{
+    fn pdf(&self, x: <Self::Support as Space>::Value) -> Probability {
+        Probability::new_unchecked(self.components.iter()
+            .zip(self.dist.ps.iter())
+            .filter_map(|(c, &p)| if p.non_zero() {
+                Some(f64::from(p * c.pdf(x.clone())))
+            } else {
+                None
+            })
+            .sum()
+        )
+    }
+}
+
+impl<C: UnivariateMoments> UnivariateMoments for Mixture<C> {
+    fn mean(&self) -> f64 {
+        self.components.iter()
+            .zip(self.dist.ps.iter())
+            .filter_map(|(c, &p)| if p.non_zero() {
+                Some(f64::from(p) * c.mean())
+            } else {
+                None
+            })
+            .sum()
+    }
+
+    fn variance(&self) -> f64 {
+        let mean = self.mean();
+        let var_term: f64 = self.components.iter()
+            .zip(self.dist.ps.iter())
+            .filter_map(|(c, &p)| if p.non_zero() {
+                let c_mean = c.mean();
+                let c_variance = c.variance();
+
+                Some(f64::from(p) * (c_mean * c_mean + c_variance))
+            } else {
+                None
+            })
+            .sum();
+
+        var_term - mean * mean
+    }
+
+    fn skewness(&self) -> f64 {
+        unimplemented!()
+    }
+
+    fn kurtosis(&self) -> f64 {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Uniform,
+        core::UnivariateMoments,
+    };
+    use super::Mixture;
+
+    #[test]
+    fn test_uniform_pair_mixture() {
+        let uniform = Uniform::<f64>::new(0.0, 2.0);
+        let mixture = Mixture::homogeneous(vec![
+            Uniform::<f64>::new(0.0, 1.0),
+            Uniform::<f64>::new(1.0, 2.0),
+        ]);
+
+        assert!((uniform.mean() - mixture.mean()).abs() < 1e-7);
+        assert!((uniform.variance() - mixture.variance()).abs() < 1e-7);
+    }
+}

--- a/src/uniform.rs
+++ b/src/uniform.rs
@@ -10,7 +10,7 @@ use spaces::{
 use std::fmt;
 
 #[derive(Debug, Clone, Copy)]
-pub struct Uniform<T = f64> {
+pub struct Uniform<T> {
     pub a: T,
     pub b: T,
 


### PR DESCRIPTION
This PR adds support for Mixture<D> distributions. These are the basis for support mixture models in the framework. For now we ignore the complexities of fitting these models and just support the basic building blocks. Eventually it would be good to add support for MLE of specific cases (i.e. GMM) and perhaps more advanced Bayesian methods etc etc.